### PR TITLE
Use changeEtherBalances to test withdraw

### DIFF
--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -52,10 +52,9 @@ describe('ERC721M', function () {
       (await contract.provider.getBalance(contract.address)).toNumber(),
     ).to.equal(100);
 
-    await contract.withdraw();
-
-    // TODO: fix the 'Provider not found' error here
-    // await expect(contract.withdraw()).to.changeEtherBalance(owner.address, 100);
+    await expect(() =>
+      contract.withdraw(),
+    ).to.changeEtherBalances([contract, owner], [-100, 100]);
 
     expect(
       (await contract.provider.getBalance(contract.address)).toNumber(),
@@ -672,7 +671,7 @@ describe('ERC721M', function () {
 
       [owner, readonly] = await ethers.getSigners();
       const ownerConn = erc721M.connect(owner);
-      
+
       await ownerConn.setStages(
         [ethers.utils.parseEther('0.5')],
         [0],


### PR DESCRIPTION
The problem was that it was using `changeEtherBalance` that expects only an account. Now it uses `changeEtherBalances` that expects an method call.