### PR TITLE
Pack stage struct to save storage/gas

### DIFF
--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -198,10 +198,10 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable {
 
     function updateStage(
         uint256 index,
-        uint256 price,
+        uint80 price,
         uint32 walletLimit,
         bytes32 merkleRoot,
-        uint256 maxStageSupply,
+        uint24 maxStageSupply,
         uint64 startTimeUnixSeconds,
         uint64 endTimeUnixSeconds
     ) external onlyOwner {
@@ -240,7 +240,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable {
     function mint(
         uint32 qty,
         bytes32[] calldata proof,
-        uint256 timestamp,
+        uint64 timestamp,
         bytes calldata signature
     ) external payable {
         _mintInternal(qty, msg.sender, proof, timestamp, signature);
@@ -250,7 +250,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable {
         uint32 qty,
         address to,
         bytes32[] calldata proof,
-        uint256 timestamp,
+        uint64 timestamp,
         bytes calldata signature
     ) external payable {
         if (_crossmintAddress == address(0)) revert CrossmintAddressNotSet();
@@ -265,7 +265,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable {
         uint32 qty,
         address to,
         bytes32[] calldata proof,
-        uint256 timestamp,
+        uint64 timestamp,
         bytes calldata signature
     ) internal canMint hasSupply(qty) {
         if (_activeStage >= _mintStages.length) revert InvalidStage();
@@ -421,12 +421,12 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable {
         revert InvalidStage();
     }
 
-    function _assertValidTimestamp(uint256 timestamp) internal view {
+    function _assertValidTimestamp(uint64 timestamp) internal view {
         if (timestamp < block.timestamp - MIN_STAGE_INTERVAL_SECONDS)
             revert TimestampExpired();
     }
 
-    function _assertValidStartAndEndTimestamp(uint256 start, uint256 end)
+    function _assertValidStartAndEndTimestamp(uint64 start, uint64 end)
         internal
         pure
     {

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -25,22 +25,22 @@ interface IERC721M {
     error WithdrawFailed();
 
     struct MintStageInfo {
-        uint256 price;
+        uint80 price;
         uint32 walletLimit; // 0 for unlimited
         bytes32 merkleRoot; // 0x0 for no presale enforced
-        uint256 maxStageSupply; // 0 for unlimited
-        uint256 startTimeUnixSeconds;
-        uint256 endTimeUnixSeconds;
+        uint24 maxStageSupply; // 0 for unlimited
+        uint64 startTimeUnixSeconds;
+        uint64 endTimeUnixSeconds;
     }
 
     event UpdateStage(
         uint256 stage,
-        uint256 price,
+        uint80 price,
         uint32 walletLimit,
         bytes32 merkleRoot,
-        uint256 maxStageSupply,
-        uint256 startTimeUnixSeconds,
-        uint256 endTimeUnixSeconds
+        uint24 maxStageSupply,
+        uint64 startTimeUnixSeconds,
+        uint64 endTimeUnixSeconds
     );
 
     event SetCosigner(address cosigner);

--- a/cosign-server/src/index.ts
+++ b/cosign-server/src/index.ts
@@ -110,7 +110,7 @@ router.post(
 
     const cosigner = getCosigner();
     const digest = keccak256(
-      ['address', 'address', 'uint32', 'address', 'uint256'],
+      ['address', 'address', 'uint32', 'address', 'uint64'],
       [
         payload.collectionContract.toLowerCase(),
         payload.minter,

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -147,14 +147,14 @@ describe('ERC721M', function () {
       let [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.5'));
       expect(stageInfo.walletLimit).to.equal(3);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(5);
+      expect(stageInfo.maxStageSupply).to.equal(5);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x1', 32));
       expect(walletMintedCount).to.equal(0);
 
       [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
       expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(10);
+      expect(stageInfo.maxStageSupply).to.equal(10);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x2', 32));
       expect(walletMintedCount).to.equal(0);
 
@@ -174,7 +174,7 @@ describe('ERC721M', function () {
       [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
       expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(0);
+      expect(stageInfo.maxStageSupply).to.equal(0);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x3', 32));
       expect(walletMintedCount).to.equal(0);
 
@@ -201,7 +201,7 @@ describe('ERC721M', function () {
       [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.7'));
       expect(stageInfo.walletLimit).to.equal(5);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(5);
+      expect(stageInfo.maxStageSupply).to.equal(5);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x4', 32));
       expect(walletMintedCount).to.equal(0);
     });
@@ -231,14 +231,14 @@ describe('ERC721M', function () {
       let [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.5'));
       expect(stageInfo.walletLimit).to.equal(3);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(5);
+      expect(stageInfo.maxStageSupply).to.equal(5);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x1', 32));
       expect(walletMintedCount).to.equal(0);
 
       [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
       expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(10);
+      expect(stageInfo.maxStageSupply).to.equal(10);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x2', 32));
       expect(walletMintedCount).to.equal(0);
 
@@ -270,7 +270,7 @@ describe('ERC721M', function () {
       [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.1'));
       expect(stageInfo.walletLimit).to.equal(13);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(15);
+      expect(stageInfo.maxStageSupply).to.equal(15);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x9', 32));
       expect(walletMintedCount).to.equal(0);
 
@@ -278,7 +278,7 @@ describe('ERC721M', function () {
       [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
       expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(10);
+      expect(stageInfo.maxStageSupply).to.equal(10);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x2', 32));
       expect(walletMintedCount).to.equal(0);
     });
@@ -368,7 +368,7 @@ describe('ERC721M', function () {
       const [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
       expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.5'));
       expect(stageInfo.walletLimit).to.equal(3);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(5);
+      expect(stageInfo.maxStageSupply).to.equal(5);
       expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x1', 32));
       expect(walletMintedCount).to.equal(0);
     });
@@ -652,7 +652,7 @@ describe('ERC721M', function () {
       );
       const [stageInfo, walletMintedCount, stagedMintedCount] =
         await readonlyContract.getStageInfo(0);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(100);
+      expect(stageInfo.maxStageSupply).to.equal(100);
       expect(walletMintedCount).to.equal(1);
       expect(stagedMintedCount.toNumber()).to.equal(1);
     });
@@ -692,7 +692,7 @@ describe('ERC721M', function () {
       );
       const [stageInfo, walletMintedCount, stagedMintedCount] =
         await readonlyContract.getStageInfo(0);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(100);
+      expect(stageInfo.maxStageSupply).to.equal(100);
       expect(walletMintedCount).to.equal(1);
       expect(stagedMintedCount.toNumber()).to.equal(1);
     });
@@ -922,7 +922,7 @@ describe('ERC721M', function () {
       let [stageInfo, walletMintedCount, stagedMintedCount] =
         await contract.getStageInfo(0);
 
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(5);
+      expect(stageInfo.maxStageSupply).to.equal(5);
       expect(walletMintedCount).to.equal(5);
       expect(stagedMintedCount.toNumber()).to.equal(5);
 
@@ -951,7 +951,7 @@ describe('ERC721M', function () {
       });
       [stageInfo, walletMintedCount, stagedMintedCount] =
         await contract.getStageInfo(1);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(10);
+      expect(stageInfo.maxStageSupply).to.equal(10);
       expect(walletMintedCount).to.equal(8);
       expect(stagedMintedCount.toNumber()).to.equal(8);
 
@@ -1106,7 +1106,7 @@ describe('ERC721M', function () {
 
       const [stageInfo, walletMintedCount, stagedMintedCount] =
         await ownerConn.getStageInfo(0);
-      expect(stageInfo.maxStageSupply.toNumber()).to.equal(100);
+      expect(stageInfo.maxStageSupply).to.equal(100);
       expect(walletMintedCount).to.equal(0);
       expect(stagedMintedCount.toNumber()).to.equal(1);
     });


### PR DESCRIPTION
- Saves ~50% gas on `setStages` (~490k -> 250k)
- New limits:
  - max price = 1.2M ETH
  - max stage supply = 16.7 million