### PR TITLE
Add view methods to IERC721M

### DIFF
--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -64,7 +64,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         _;
     }
 
-    function getCosigner() external view returns (address) {
+    function getCosigner() external view override returns (address) {
         return _cosigner;
     }
 
@@ -73,7 +73,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit SetCosigner(cosigner);
     }
 
-    function getCrossmintAddress() external view returns (address) {
+    function getCrossmintAddress() external view override returns (address) {
         return _crossmintAddress;
     }
 
@@ -124,7 +124,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         }
     }
 
-    function getMintable() external view returns (bool) {
+    function getMintable() external view override returns (bool) {
         return _mintable;
     }
 
@@ -133,11 +133,11 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit SetMintable(mintable);
     }
 
-    function getNumberStages() external view returns (uint256) {
+    function getNumberStages() external view override returns (uint256) {
         return _mintStages.length;
     }
 
-    function getMaxMintableSupply() public view returns (uint256) {
+    function getMaxMintableSupply() external view override returns (uint256) {
         return _maxMintableSupply;
     }
 
@@ -152,7 +152,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit SetMaxMintableSupply(maxMintableSupply);
     }
 
-    function getGlobalWalletLimit() external view returns (uint256) {
+    function getGlobalWalletLimit() external view override returns (uint256) {
         return _globalWalletLimit;
     }
 
@@ -166,7 +166,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit SetGlobalWalletLimit(globalWalletLimit);
     }
 
-    function getActiveStage() external view returns (uint256) {
+    function getActiveStage() external view override returns (uint256) {
         return _activeStage;
     }
 
@@ -176,13 +176,19 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit SetActiveStage(activeStage);
     }
 
-    function totalMintedByAddress(address a) external view returns (uint256) {
+    function totalMintedByAddress(address a)
+        external
+        view
+        override
+        returns (uint256)
+    {
         return _numberMinted(a);
     }
 
     function getStageInfo(uint256 index)
         external
         view
+        override
         returns (
             MintStageInfo memory,
             uint32,
@@ -344,7 +350,12 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         emit PermanentBaseURI(_currentBaseURI);
     }
 
-    function getTokenURISuffix() external view returns (string memory) {
+    function getTokenURISuffix()
+        external
+        view
+        override
+        returns (string memory)
+    {
         return _tokenURISuffix;
     }
 
@@ -355,7 +366,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     function tokenURI(uint256 tokenId)
         public
         view
-        override
+        override(ERC721A, IERC721A)
         returns (string memory)
     {
         if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
@@ -396,7 +407,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         uint32 qty,
         uint256 timestamp,
         bytes memory signature
-    ) public view {
+    ) public view override {
         if (
             !SignatureChecker.isValidSignatureNow(
                 _cosigner,
@@ -406,9 +417,10 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         ) revert InvalidCosignSignature();
     }
 
-    function getActiveStageFromTimestamp(uint256 timestamp)
+    function getActiveStageFromTimestamp(uint64 timestamp)
         public
         view
+        override
         returns (uint256)
     {
         for (uint256 i = 0; i < _mintStages.length; i++) {

--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -387,7 +387,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     function getCosignDigest(
         address minter,
         uint32 qty,
-        uint256 timestamp
+        uint64 timestamp
     ) public view returns (bytes32) {
         if (_cosigner == address(0)) revert CosignerNotSet();
         return
@@ -405,7 +405,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     function assertValidCosign(
         address minter,
         uint32 qty,
-        uint256 timestamp,
+        uint64 timestamp,
         bytes memory signature
     ) public view override {
         if (

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -90,7 +90,7 @@ interface IERC721M is IERC721AQueryable {
     function assertValidCosign(
         address minter,
         uint32 qty,
-        uint256 timestamp,
+        uint64 timestamp,
         bytes memory signature
     ) external view;
 }

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -1,7 +1,9 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-interface IERC721M {
+import "erc721a/contracts/extensions/IERC721AQueryable.sol";
+
+interface IERC721M is IERC721AQueryable {
     error CannotIncreaseMaxMintableSupply();
     error CannotUpdatePermanentBaseURI();
     error CosignerNotSet();
@@ -52,4 +54,43 @@ interface IERC721M {
     event SetBaseURI(string baseURI);
     event PermanentBaseURI(string baseURI);
     event Withdraw(uint256 value);
+
+    function getCosigner() external view returns (address);
+
+    function getCrossmintAddress() external view returns (address);
+
+    function getNumberStages() external view returns (uint256);
+
+    function getGlobalWalletLimit() external view returns (uint256);
+
+    function getMaxMintableSupply() external view returns (uint256);
+
+    function getMintable() external view returns (bool);
+
+    function totalMintedByAddress(address a) external view returns (uint256);
+
+    function getTokenURISuffix() external view returns (string memory);
+
+    function getStageInfo(uint256 index)
+        external
+        view
+        returns (
+            MintStageInfo memory,
+            uint32,
+            uint256
+        );
+
+    function getActiveStage() external view returns (uint256);
+
+    function getActiveStageFromTimestamp(uint64 timestamp)
+        external
+        view
+        returns (uint256);
+
+    function assertValidCosign(
+        address minter,
+        uint32 qty,
+        uint256 timestamp,
+        bytes memory signature
+    ) external view;
 }

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -675,7 +675,7 @@ describe('ERC721M', function () {
 
       const timestamp = stageStart + 500;
       const digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [contract.address, minter.address, 1, cosigner.address, timestamp],
       );
       const sig = await cosigner.signMessage(
@@ -714,7 +714,7 @@ describe('ERC721M', function () {
 
       const timestamp = Math.floor(new Date().getTime() / 1000);
       const digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [contract.address, minter.address, 1, cosigner.address, timestamp],
       );
       const sig = await cosigner.signMessage(
@@ -809,7 +809,7 @@ describe('ERC721M', function () {
 
       const earlyTimestamp = stageStart - 1;
       let digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [contract.address, minter.address, 1, cosigner.address, earlyTimestamp],
       );
       let sig = await cosigner.signMessage(ethers.utils.arrayify(digestFromJs));
@@ -828,7 +828,7 @@ describe('ERC721M', function () {
 
       const lateTimestamp = stageStart + 1001;
       digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [contract.address, minter.address, 1, cosigner.address, lateTimestamp],
       );
       sig = await cosigner.signMessage(ethers.utils.arrayify(digestFromJs));
@@ -867,7 +867,7 @@ describe('ERC721M', function () {
 
       const timestamp = stageStart;
       const digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [contract.address, minter.address, 1, cosigner.address, timestamp],
       );
       const sig = await cosigner.signMessage(
@@ -1501,7 +1501,7 @@ describe('ERC721M', function () {
 
       const timestamp = Math.floor(new Date().getTime() / 1000);
       const digestFromJs = ethers.utils.solidityKeccak256(
-        ['address', 'address', 'uint32', 'address', 'uint256'],
+        ['address', 'address', 'uint32', 'address', 'uint64'],
         [erc721M.address, minter.address, 1, cosigner.address, timestamp],
       );
       const sig = await cosigner.signMessage(


### PR DESCRIPTION
- We can implement read proxies for arbitrary minting contracts with some pattern like this:

```
contract SomeERC721 {}

contract SomeERC721Adapter is IERC721M {}
```

Also fix timestamp sizes in test