### PR TITLE
Add test for ReentrancyGuard correctly triggered

### DIFF
--- a/contracts/TestReentrantExploit.sol
+++ b/contracts/TestReentrantExploit.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./ERC721M.sol";
+
+contract TestReentrantExploit {
+    address private _targetContract;
+
+    constructor(address target) {
+        _targetContract = target;
+    }
+
+    function exploit(
+        uint32 qty,
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature
+    ) public payable {
+        ERC721M(_targetContract).mint{value: msg.value}(
+            qty,
+            proof,
+            timestamp,
+            signature
+        );
+    }
+
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) public payable returns (bytes4) {
+        bytes32[] memory proof;
+        ERC721M(_targetContract).mint{value: msg.value}(1, proof, 0, "");
+        return ERC721A__IERC721Receiver(operator).onERC721Received.selector;
+    }
+}


### PR DESCRIPTION
- Add `TestReentrantExploit` which will try to go back into the `mint` method during the `onERC721Received` check (called during `_safeMint`)