### PR TITLE
Add ERC721MCallback extension

### DIFF
--- a/contracts/ERC721MCallback.sol
+++ b/contracts/ERC721MCallback.sol
@@ -1,0 +1,94 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./ERC721M.sol";
+import "./IERC721MCallback.sol";
+
+contract ERC721MCallback is ERC721M, IERC721MCallback {
+    CallbackInfo[] private _callbackInfos;
+    address[] private _onMintApprovals;
+
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner
+    )
+        ERC721M(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner
+        )
+    {}
+
+    function getCallbackInfos() external view returns (CallbackInfo[] memory) {
+        return _callbackInfos;
+    }
+
+    function getOnMintApprovals() external view returns (address[] memory) {
+        return _onMintApprovals;
+    }
+
+    function setCallbackInfos(CallbackInfo[] calldata callbackInfos)
+        external
+        onlyOwner
+    {
+        uint256 length = _callbackInfos.length;
+        for (uint256 i = 0; i < length; i++) {
+            _callbackInfos.pop();
+        }
+
+        for (uint256 i = 0; i < callbackInfos.length; i++) {
+            _callbackInfos.push(callbackInfos[i]);
+        }
+    }
+
+    function setOnMintApprovals(address[] calldata onMintApprovals)
+        external
+        onlyOwner
+    {
+        _onMintApprovals = onMintApprovals;
+    }
+
+    function mintWithCallbacks(
+        uint32 qty,
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature,
+        bytes[] calldata callbackDatas
+    ) external payable {
+        _mintInternal(qty, msg.sender, proof, timestamp, signature);
+
+        if (callbackDatas.length != _callbackInfos.length) {
+            revert InvalidCallbackDatasLength(
+                _callbackInfos.length,
+                callbackDatas.length
+            );
+        }
+
+        for (uint256 i = 0; i < _onMintApprovals.length; i++) {
+            if (!isApprovedForAll(msg.sender, _onMintApprovals[i])) {
+                setApprovalForAll(_onMintApprovals[i], true);
+            }
+        }
+
+        for (uint256 i = 0; i < _callbackInfos.length; i++) {
+            CallbackInfo memory cbInfo = _callbackInfos[i];
+            (bool success, ) = cbInfo.callbackContract.call(
+                abi.encodePacked(cbInfo.callbackFunction, callbackDatas[i])
+            );
+
+            if (!success) {
+                revert CallbackFailed(
+                    cbInfo.callbackContract,
+                    cbInfo.callbackFunction
+                );
+            }
+        }
+    }
+}

--- a/contracts/IERC721MCallback.sol
+++ b/contracts/IERC721MCallback.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./ERC721M.sol";
+
+interface IERC721MCallback is IERC721M {
+    struct CallbackInfo {
+        address callbackContract;
+        bytes4 callbackFunction;
+    }
+
+    error CallbackFailed(address callbackContract, bytes4 callbackFunction);
+    error InvalidCallbackDatasLength(uint256 expected, uint256 actual);
+}

--- a/contracts/mocks/TestReentrantExploit.sol
+++ b/contracts/mocks/TestReentrantExploit.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "./ERC721M.sol";
+import "../ERC721M.sol";
 
 contract TestReentrantExploit {
     address private _targetContract;

--- a/contracts/mocks/TestStaking.sol
+++ b/contracts/mocks/TestStaking.sol
@@ -1,0 +1,43 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "erc721a/contracts/ERC721A.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+contract TestStaking {
+    using EnumerableSet for EnumerableSet.UintSet;
+    IERC721A private _nft;
+    mapping(address => EnumerableSet.UintSet) private _stakers;
+
+    constructor(address nft) {
+        _nft = IERC721A(nft);
+    }
+
+    function isStaked(address staker, uint256 tokenId)
+        public
+        view
+        returns (bool)
+    {
+        return _stakers[staker].contains(tokenId);
+    }
+
+    function stake(uint256 tokenId) public {
+        _nft.transferFrom(msg.sender, address(this), tokenId);
+        _stakers[msg.sender].add(tokenId);
+    }
+
+    function stakeFor(address staker, uint256 tokenId) public {
+        require(
+            msg.sender == address(_nft),
+            "Only NFT contract can stake on behalf"
+        );
+        _nft.transferFrom(staker, address(this), tokenId);
+        _stakers[staker].add(tokenId);
+    }
+
+    function unstake(uint256 tokenId) public {
+        require(_stakers[msg.sender].contains(tokenId), "Not staked");
+        _nft.transferFrom(address(this), msg.sender, tokenId);
+        _stakers[msg.sender].remove(tokenId);
+    }
+}

--- a/test/ERC721MCallback.test.ts
+++ b/test/ERC721MCallback.test.ts
@@ -1,0 +1,235 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import chai, { assert, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { ethers } from 'hardhat';
+import {
+  ERC721MCallback,
+  TestStaking,
+  TestStaking__factory,
+} from '../typechain-types';
+
+chai.use(chaiAsPromised);
+
+describe.only('ERC721MCallback', () => {
+  let contract: ERC721MCallback;
+  let readonlyContract: ERC721MCallback;
+  let stakingContract: TestStaking;
+  let readonlyStakingContract: TestStaking;
+  let owner: SignerWithAddress;
+  let readonly: SignerWithAddress;
+
+  beforeEach(async () => {
+    const factory = await ethers.getContractFactory('ERC721MCallback');
+    const erc721mCallback = await factory.deploy(
+      'Test',
+      'TST',
+      '.json',
+      100,
+      0,
+      ethers.constants.AddressZero,
+    );
+    await erc721mCallback.deployed();
+
+    const [ownerSigner, readonlySigner] = await ethers.getSigners();
+    owner = ownerSigner;
+    readonly = readonlySigner;
+    contract = erc721mCallback.connect(ownerSigner);
+    readonlyContract = erc721mCallback.connect(readonlySigner);
+
+    const stakingFactory = await ethers.getContractFactory('TestStaking');
+    stakingContract = await stakingFactory.deploy(erc721mCallback.address);
+    await stakingContract.deployed();
+
+    readonlyStakingContract = stakingContract.connect(readonlySigner);
+  });
+
+  describe('Setting callbacks', () => {
+    it('Can set callbacks', async () => {
+      await contract.setCallbackInfos([
+        {
+          callbackContract: stakingContract.address,
+          callbackFunction: '0x00000000',
+        },
+      ]);
+
+      let callbackInfos = await readonlyContract.getCallbackInfos();
+      expect(callbackInfos.length).to.equal(1);
+      expect(callbackInfos[0].callbackContract).to.equal(
+        stakingContract.address,
+      );
+      expect(callbackInfos[0].callbackFunction).to.equal('0x00000000');
+
+      await contract.setCallbackInfos([
+        {
+          callbackContract: stakingContract.address,
+          callbackFunction: '0x00000000',
+        },
+        {
+          callbackContract: owner.address,
+          callbackFunction: '0x00000001',
+        },
+      ]);
+
+      callbackInfos = await readonlyContract.getCallbackInfos();
+      expect(callbackInfos.length).to.equal(2);
+      expect(callbackInfos[0].callbackContract).to.equal(
+        stakingContract.address,
+      );
+      expect(callbackInfos[0].callbackFunction).to.equal('0x00000000');
+      expect(callbackInfos[1].callbackContract).to.equal(owner.address);
+      expect(callbackInfos[1].callbackFunction).to.equal('0x00000001');
+    });
+  });
+
+  describe('Minting', () => {
+    it('Callbacks should be triggered', async () => {
+      await contract.setStages([
+        {
+          price: ethers.utils.parseEther('0.1'),
+          walletLimit: 0,
+          maxStageSupply: 0,
+          merkleRoot: ethers.utils.hexZeroPad('0x', 32),
+          startTimeUnixSeconds: 0,
+          endTimeUnixSeconds: 1,
+        },
+      ]);
+      await contract.setMintable(true);
+      const stakeFunctionSelector = new ethers.utils.Interface(
+        TestStaking__factory.abi,
+      )
+        .encodeFunctionData('stakeFor', [ethers.constants.AddressZero, 0])
+        .slice(0, 10);
+      await contract.setCallbackInfos([
+        {
+          callbackContract: stakingContract.address,
+          callbackFunction: stakeFunctionSelector,
+        },
+      ]);
+      await contract.setOnMintApprovals([stakingContract.address]);
+
+      expect(await contract.getOnMintApprovals()).to.deep.equal([
+        stakingContract.address,
+      ]);
+
+      await readonlyContract.mintWithCallbacks(
+        1,
+        [],
+        0,
+        '0x',
+        [
+          '0x' +
+            new ethers.utils.Interface(TestStaking__factory.abi)
+              .encodeFunctionData('stakeFor', [readonly.address, 0])
+              .slice(10),
+        ],
+        {
+          value: ethers.utils.parseEther('0.1'),
+        },
+      );
+
+      expect(await contract.totalSupply()).to.equal(1);
+      expect(await contract.balanceOf(readonly.address)).to.equal(0);
+      expect(await contract.balanceOf(stakingContract.address)).to.equal(1);
+      expect(await stakingContract.isStaked(readonly.address, 0)).to.equal(
+        true,
+      );
+
+      // Unstake
+      await readonlyStakingContract.unstake(0);
+
+      expect(await contract.balanceOf(readonly.address)).to.equal(1);
+      expect(await contract.balanceOf(stakingContract.address)).to.equal(0);
+      expect(await stakingContract.isStaked(readonly.address, 0)).to.equal(
+        false,
+      );
+    });
+
+    it('Reverts when not enough callbacks passed', async () => {
+      await contract.setStages([
+        {
+          price: ethers.utils.parseEther('0.1'),
+          walletLimit: 0,
+          maxStageSupply: 0,
+          merkleRoot: ethers.utils.hexZeroPad('0x', 32),
+          startTimeUnixSeconds: 0,
+          endTimeUnixSeconds: 1,
+        },
+      ]);
+      await contract.setMintable(true);
+      const stakeFunctionSelector = new ethers.utils.Interface(
+        TestStaking__factory.abi,
+      )
+        .encodeFunctionData('stakeFor', [ethers.constants.AddressZero, 0])
+        .slice(0, 10);
+      await contract.setCallbackInfos([
+        {
+          callbackContract: stakingContract.address,
+          callbackFunction: stakeFunctionSelector,
+        },
+      ]);
+      await contract.setOnMintApprovals([stakingContract.address]);
+
+      await expect(
+        readonlyContract.mintWithCallbacks(1, [], 0, '0x', [], {
+          value: ethers.utils.parseEther('0.1'),
+        }),
+      ).to.be.revertedWith('InvalidCallbackDatasLength');
+    });
+
+    it('Reverts when callback fails', async () => {
+      await contract.setStages([
+        {
+          price: ethers.utils.parseEther('0.1'),
+          walletLimit: 0,
+          maxStageSupply: 0,
+          merkleRoot: ethers.utils.hexZeroPad('0x', 32),
+          startTimeUnixSeconds: 0,
+          endTimeUnixSeconds: 1,
+        },
+      ]);
+      await contract.setMintable(true);
+      const stakeFunctionSelector = new ethers.utils.Interface(
+        TestStaking__factory.abi,
+      )
+        .encodeFunctionData('stakeFor', [ethers.constants.AddressZero, 0])
+        .slice(0, 10);
+      await contract.setCallbackInfos([
+        {
+          callbackContract: stakingContract.address,
+          callbackFunction: stakeFunctionSelector,
+        },
+      ]);
+      await contract.setOnMintApprovals([stakingContract.address]);
+
+      await expect(
+        readonlyContract.mintWithCallbacks(1, [], 0, '0x', ['0x1234'], {
+          value: ethers.utils.parseEther('0.1'),
+        }),
+      ).to.be.revertedWith('CallbackFailed');
+    });
+
+    it('can mint normally', async () => {
+      await contract.setStages([
+        {
+          price: ethers.utils.parseEther('0.1'),
+          walletLimit: 0,
+          maxStageSupply: 0,
+          merkleRoot: ethers.utils.hexZeroPad('0x', 32),
+          startTimeUnixSeconds: 0,
+          endTimeUnixSeconds: 1,
+        },
+      ]);
+      await contract.setMintable(true);
+
+      await readonlyContract.mint(1, [], 0, '0x', {
+        value: ethers.utils.parseEther('0.1'),
+      });
+
+      expect(await readonlyContract.balanceOf(readonly.address)).to.equal(1);
+      expect(await readonlyContract.totalSupply()).to.equal(1);
+      expect(
+        await readonlyContract.balanceOf(stakingContract.address),
+      ).to.equal(0);
+    });
+  });
+});

--- a/test/ERC721MCallback.test.ts
+++ b/test/ERC721MCallback.test.ts
@@ -10,7 +10,7 @@ import {
 
 chai.use(chaiAsPromised);
 
-describe.only('ERC721MCallback', () => {
+describe('ERC721MCallback', () => {
   let contract: ERC721MCallback;
   let readonlyContract: ERC721MCallback;
   let stakingContract: TestStaking;

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -3,7 +3,7 @@ import chai, { assert, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'hardhat';
 import { MerkleTree } from 'merkletreejs';
-import { ERC721M, TestReentrantExploit__factory } from '../typechain-types';
+import { ERC721M } from '../typechain-types';
 
 const { keccak256, getAddress } = ethers.utils;
 


### PR DESCRIPTION
- New `ERC721MCallback` extension which allows the owner to specify some callback contracts + methods to be called. Example use case is automatically staking newly minted NFTS.
- A list of contracts that should be granted `ApprovalForAll` can be set via `setOnMintApprovals` (necessary for staking contracts to transfer NFTs away from minter)
- Data for each callback is passed in a minting time via `mintWithCallbacks`