### PR TITLE
Support increasing max mintable supply with method to disable

### DIFF
--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -39,7 +39,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     address private _crossmintAddress;
 
     // The total mintable supply.
-    uint256 private _maxMintableSupply;
+    uint256 internal _maxMintableSupply;
 
     // Global wallet limit, across all stages.
     uint256 private _globalWalletLimit;
@@ -257,6 +257,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      */
     function setMaxMintableSupply(uint256 maxMintableSupply)
         external
+        virtual
         onlyOwner
     {
         if (maxMintableSupply > _maxMintableSupply) {

--- a/contracts/ERC721MIncreasableSupply.sol
+++ b/contracts/ERC721MIncreasableSupply.sol
@@ -1,0 +1,69 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "./ERC721M.sol";
+
+contract ERC721MIncreasableSupply is ERC721M {
+    // Whether mintable supply can increase. Once set to false, _maxMintableSupply can never increase.
+    bool private _canIncreaseMaxMintableSupply;
+
+    event DisableIncreaseMaxMintableSupply();
+
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner,
+        uint64 timestampExpirySeconds
+    )
+        ERC721M(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner,
+            timestampExpirySeconds
+        )
+    {
+        _canIncreaseMaxMintableSupply = true;
+    }
+
+    /**
+     * @dev Return true if max mintable supply can be increased.
+     */
+    function getCanIncreaseMaxMintableSupply() external view returns (bool) {
+        return _canIncreaseMaxMintableSupply;
+    }
+
+    /**
+     * @dev Makes _canIncreaseMaxMintableSupply false permanently.
+     */
+    function disableIncreaseMaxMintableSupply() external onlyOwner {
+        _canIncreaseMaxMintableSupply = false;
+        emit DisableIncreaseMaxMintableSupply();
+    }
+
+    /**
+     * @dev Sets maximum mintable supply.
+     *
+     * New supply cannot be larger than the old, unless _canIncreaseMaxMintableSupply is true.
+     */
+    function setMaxMintableSupply(uint256 maxMintableSupply)
+        external
+        override
+        onlyOwner
+    {
+        if (
+            !_canIncreaseMaxMintableSupply &&
+            maxMintableSupply > _maxMintableSupply
+        ) {
+            revert CannotIncreaseMaxMintableSupply();
+        }
+        _maxMintableSupply = maxMintableSupply;
+        emit SetMaxMintableSupply(maxMintableSupply);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -93,6 +93,10 @@ task('deploy', 'Deploy ERC721M')
     'cosigner address (0x00...000 if not using cosign)',
     '0x0000000000000000000000000000000000000000',
   )
+  .addFlag(
+    'increasesupply',
+    'whether or not to enable increasing supply behavior',
+  )
   .setAction(deploy);
 
 task('setBaseURI', 'Set the base uri')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magiceden-oss/erc721m",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magiceden-oss/erc721m",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
         "erc721a": "^4.2.3"

--- a/scripts/common/constants.ts
+++ b/scripts/common/constants.ts
@@ -3,4 +3,5 @@
 export const ContractDetails = {
   ERC721M: { name: 'ERC721M' }, // The contract of direct sales
   BucketAuction: { name: 'BucketAuction' }, // The contract of bucket auctions
-};
+  ERC721MIncreasableSupply: { name: 'ERC721MIncreasableSupply' }, // ERC721M with increasable supply
+} as const;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -14,20 +14,24 @@ export interface IDeployParams {
   globalwalletlimit: string;
   cosigner?: string;
   timestampexpiryseconds?: number;
+  increasesupply?: boolean;
 }
 
 export const deploy = async (
   args: IDeployParams,
   hre: HardhatRuntimeEnvironment,
 ) => {
+  // Compile again in case we have a coverage build (binary too large to deploy)
+  await hre.run('compile');
+
+  const contractName = args.increasesupply
+    ? ContractDetails.ERC721MIncreasableSupply.name
+    : ContractDetails.ERC721M.name;
   console.log(
-    `Going to deploy ${ContractDetails.ERC721M.name} with params`,
+    `Going to deploy ${contractName} with params`,
     JSON.stringify(args, null, 2),
   );
-
-  const ERC721M = await hre.ethers.getContractFactory(
-    ContractDetails.ERC721M.name,
-  );
+  const ERC721M = await hre.ethers.getContractFactory(contractName);
 
   const erc721M = await ERC721M.deploy(
     args.name,
@@ -41,5 +45,5 @@ export const deploy = async (
 
   await erc721M.deployed();
 
-  console.log(`${ContractDetails.ERC721M.name} deployed to:`, erc721M.address);
+  console.log(`${contractName} deployed to:`, erc721M.address);
 };

--- a/test/ERC721MIncreasableSupply.test.ts
+++ b/test/ERC721MIncreasableSupply.test.ts
@@ -1,0 +1,40 @@
+import { ERC721MIncreasableSupply } from '../typechain-types';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+describe('ERC721MIncreasableSupply', () => {
+  let contract: ERC721MIncreasableSupply;
+
+  beforeEach(async () => {
+    const factory = await ethers.getContractFactory('ERC721MIncreasableSupply');
+    contract = await factory.deploy(
+      'test',
+      'TEST',
+      '.json',
+      1000,
+      0,
+      ethers.constants.AddressZero,
+      300,
+    );
+    const [owner] = await ethers.getSigners();
+    contract = contract.connect(owner);
+    await contract.deployed();
+  });
+
+  it('can increase max mintable supply until disableIncreaseMaxMintableSupply called', async () => {
+    const currentSupply = await contract.getMaxMintableSupply();
+    expect(await contract.getCanIncreaseMaxMintableSupply()).to.eq(true);
+    await expect(contract.setMaxMintableSupply(currentSupply.add(1000)))
+      .to.emit(contract, 'SetMaxMintableSupply')
+      .withArgs(currentSupply.toNumber() + 1000);
+
+    await expect(contract.disableIncreaseMaxMintableSupply()).to.emit(
+      contract,
+      'DisableIncreaseMaxMintableSupply',
+    );
+    expect(await contract.getCanIncreaseMaxMintableSupply()).to.eq(false);
+    await expect(
+      contract.setMaxMintableSupply(currentSupply.add(2000)),
+    ).to.be.revertedWith('CannotIncreaseMaxMintableSupply');
+  });
+});

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -697,7 +697,6 @@ describe('ERC721M', function () {
       await contract.setMaxMintableSupply(98);
       expect(await contract.getMaxMintableSupply()).to.equal(98);
 
-      // can not set the mintable supply with higher value
       await expect(contract.setMaxMintableSupply(100)).to.be.rejectedWith(
         'CannotIncreaseMaxMintableSupply',
       );

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -697,6 +697,7 @@ describe('ERC721M', function () {
       await contract.setMaxMintableSupply(98);
       expect(await contract.getMaxMintableSupply()).to.equal(98);
 
+      // can not set the mintable supply with higher value
       await expect(contract.setMaxMintableSupply(100)).to.be.rejectedWith(
         'CannotIncreaseMaxMintableSupply',
       );


### PR DESCRIPTION
- Adds a new extension `ERC721MIncreasableSupply` which allows owner to increase supply, and permanently + irreversibly disable this behavior with `disableIncreaseMaxMintableSupply`
- To deploy, add `--increasesupply` to the deploy args:

```
npx hardhat --network goerli deploy --name "testing" --symbol testing --maxsupply 6000 --globalwalletlimit 0 --tokenurisuffix .json --cosigner 0x194Ea7ce80b510d6B872B1D221C6230eBF83bFF9 --timestampexpiryseconds 600 --increasesupply
```