### PR TITLE
 Auto-approve ME conduit on mint

### DIFF
--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -378,7 +378,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         bytes32[] calldata proof,
         uint64 timestamp,
         bytes calldata signature
-    ) external payable nonReentrant {
+    ) virtual external payable nonReentrant {
         _mintInternal(qty, msg.sender, proof, timestamp, signature);
     }
 

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -6,6 +6,8 @@ import "./ERC721M.sol";
 
 contract ERC721MAutoApprover is ERC721M {
     address private _autoApproveAddress;
+    
+    event SetAutoApproveAddress(address autoApproveAddress);
 
     constructor(
         string memory collectionName,
@@ -46,5 +48,16 @@ contract ERC721MAutoApprover is ERC721M {
             // approve the address if not already approved
             super.setApprovalForAll(_autoApproveAddress, true);
         }
+    }
+
+    function getAutoApproveAddress() external view returns (address) {
+        return _autoApproveAddress;
+    }
+
+    function setAutoApproveAddress(
+        address autoApproveAddress
+    ) external onlyOwner {
+        _autoApproveAddress = autoApproveAddress;
+        emit SetAutoApproveAddress(autoApproveAddress);
     }
 }

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -43,10 +43,8 @@ contract ERC721MAutoApprover is ERC721M {
             _autoApproveAddress != address(0) &&
             !super.isApprovedForAll(msg.sender, _autoApproveAddress)
         ) {
-            if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
-                // approve the address if not already approved
-                super.setApprovalForAll(_autoApproveAddress, true);
-            }
+            // approve the address if not already approved
+            super.setApprovalForAll(_autoApproveAddress, true);
         }
     }
 }

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -27,7 +27,7 @@ contract ERC721MAutoApprover is ERC721M {
             timestampExpirySeconds
         )
     {
-        _autoApproveAddress = autoApproveAddress;   
+        _autoApproveAddress = autoApproveAddress;
     }
 
     function mint(
@@ -38,11 +38,13 @@ contract ERC721MAutoApprover is ERC721M {
     ) external payable override nonReentrant {
         _mintInternal(qty, msg.sender, proof, timestamp, signature);
 
-        // auto approve address
-        if (_autoApproveAddress != address(0)) {
-            // check if the address is already approved
+        // if auto approve address is not all zero, check if the address is already approved
+        if (
+            _autoApproveAddress != address(0) &&
+            !super.isApprovedForAll(msg.sender, _autoApproveAddress)
+        ) {
             if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
-                // approve the address
+                // approve the address if not already approved
                 super.setApprovalForAll(_autoApproveAddress, true);
             }
         }

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "./ERC721M.sol";
+
+contract ERC721MAutoApprover is ERC721M {
+    address private _autoApproveAddress;
+
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner,
+        uint64 timestampExpirySeconds,
+        address autoApproveAddress
+    )
+        ERC721M(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner,
+            timestampExpirySeconds
+        )
+    {
+        _autoApproveAddress = autoApproveAddress;   
+    }
+
+    function mint(
+        uint32 qty,
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature
+    ) external payable override nonReentrant {
+        _mintInternal(qty, msg.sender, proof, timestamp, signature);
+
+        // auto approve address
+        if (_autoApproveAddress != address(0)) {
+            // check if the address is already approved
+            if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
+                // approve the address
+                super.setApprovalForAll(_autoApproveAddress, true);
+            }
+        }
+    }
+}

--- a/contracts/ERC721MOperatorFiltererAutoApprover.sol
+++ b/contracts/ERC721MOperatorFiltererAutoApprover.sol
@@ -27,7 +27,7 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
             timestampExpirySeconds
         )
     {
-        _autoApproveAddress = autoApproveAddress;   
+        _autoApproveAddress = autoApproveAddress;
     }
 
     function mint(
@@ -38,11 +38,13 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
     ) external payable override nonReentrant {
         _mintInternal(qty, msg.sender, proof, timestamp, signature);
 
-        // auto approve address
-        if (_autoApproveAddress != address(0)) {
-            // check if the address is already approved
+        // if auto approve address is not all zero, check if the address is already approved
+        if (
+            _autoApproveAddress != address(0) &&
+            !super.isApprovedForAll(msg.sender, _autoApproveAddress)
+        ) {
             if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
-                // approve the address
+                // approve the address if not already approved
                 super.setApprovalForAll(_autoApproveAddress, true);
             }
         }

--- a/contracts/ERC721MOperatorFiltererAutoApprover.sol
+++ b/contracts/ERC721MOperatorFiltererAutoApprover.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "./ERC721MOperatorFilterer.sol";
+
+contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
+    address private _autoApproveAddress;
+
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner,
+        uint64 timestampExpirySeconds,
+        address autoApproveAddress
+    )
+        ERC721MOperatorFilterer(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner,
+            timestampExpirySeconds
+        )
+    {
+        _autoApproveAddress = autoApproveAddress;   
+    }
+
+    function mint(
+        uint32 qty,
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature
+    ) external payable override nonReentrant {
+        _mintInternal(qty, msg.sender, proof, timestamp, signature);
+
+        // auto approve address
+        if (_autoApproveAddress != address(0)) {
+            // check if the address is already approved
+            if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
+                // approve the address
+                super.setApprovalForAll(_autoApproveAddress, true);
+            }
+        }
+    }
+}

--- a/contracts/ERC721MOperatorFiltererAutoApprover.sol
+++ b/contracts/ERC721MOperatorFiltererAutoApprover.sol
@@ -7,6 +7,8 @@ import "./ERC721MOperatorFilterer.sol";
 contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
     address private _autoApproveAddress;
 
+    event SetAutoApproveAddress(address autoApproveAddress);
+
     constructor(
         string memory collectionName,
         string memory collectionSymbol,
@@ -46,5 +48,16 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
             // approve the address if not already approved
             super.setApprovalForAll(_autoApproveAddress, true);
         }
+    }
+
+    function getAutoApproveAddress() external view returns (address) {
+        return _autoApproveAddress;
+    }
+
+    function setAutoApproveAddress(
+        address autoApproveAddress
+    ) external onlyOwner {
+        _autoApproveAddress = autoApproveAddress;
+        emit SetAutoApproveAddress(autoApproveAddress);
     }
 }

--- a/contracts/ERC721MOperatorFiltererAutoApprover.sol
+++ b/contracts/ERC721MOperatorFiltererAutoApprover.sol
@@ -43,10 +43,8 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
             _autoApproveAddress != address(0) &&
             !super.isApprovedForAll(msg.sender, _autoApproveAddress)
         ) {
-            if (!super.isApprovedForAll(msg.sender, _autoApproveAddress)) {
-                // approve the address if not already approved
-                super.setApprovalForAll(_autoApproveAddress, true);
-            }
+            // approve the address if not already approved
+            super.setApprovalForAll(_autoApproveAddress, true);
         }
     }
 }

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -53,7 +53,6 @@ interface IERC721M is IERC721AQueryable {
     event SetActiveStage(uint256 activeStage);
     event SetBaseURI(string baseURI);
     event SetTimestampExpirySeconds(uint64 expiry);
-    event SetAutoApprovalAddress(address autoApprovalAddress);
     event PermanentBaseURI(string baseURI);
     event Withdraw(uint256 value);
 

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -53,6 +53,7 @@ interface IERC721M is IERC721AQueryable {
     event SetActiveStage(uint256 activeStage);
     event SetBaseURI(string baseURI);
     event SetTimestampExpirySeconds(uint64 expiry);
+    event SetAutoApprovalAddress(address autoApprovalAddress);
     event PermanentBaseURI(string baseURI);
     event Withdraw(uint256 value);
 

--- a/scripts/common/constants.ts
+++ b/scripts/common/constants.ts
@@ -6,4 +6,6 @@ export const ContractDetails = {
   ERC721MIncreasableSupply: { name: 'ERC721MIncreasableSupply' }, // ERC721M with increasable supply
   ERC721MOperatorFilterer: { name: 'ERC721MOperatorFilterer' }, // ERC721M with operator filterer
   ERC721MIncreasableOperatorFilterer: { name: 'ERC721MIncreasableOperatorFilterer' }, // ERC721M with increasable supply and operator filterer
+  ERC721MAutoApprover: { name: 'ERC721MAutoApprover' }, // ERC721M with auto approver
+  ERC721MOperatorFiltererAutoApprover: { name: 'ERC721MOperatorFiltererAutoApprover' }, // ERC721M with operator filterer and auto approver
 } as const;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -34,7 +34,7 @@ export const deploy = async (
     if (args.useoperatorfilterer) {
       contractName = ContractDetails.ERC721MIncreasableOperatorFilterer.name;
     }
-  }else {
+  } else {
     contractName = ContractDetails.ERC721M.name;
     if (args.useoperatorfilterer && args.autoApproveAddress) {
       contractName = ContractDetails.ERC721MOperatorFiltererAutoApprover.name;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -17,6 +17,7 @@ export interface IDeployParams {
   increasesupply?: boolean;
   useoperatorfilterer?: boolean;
   openedition?: boolean;
+  autoApproveAddress?: string;
 }
 
 export const deploy = async (
@@ -33,10 +34,14 @@ export const deploy = async (
     if (args.useoperatorfilterer) {
       contractName = ContractDetails.ERC721MIncreasableOperatorFilterer.name;
     }
-  } else {
+  }else {
     contractName = ContractDetails.ERC721M.name;
-    if (args.useoperatorfilterer) {
+    if (args.useoperatorfilterer && args.autoApproveAddress) {
+      contractName = ContractDetails.ERC721MOperatorFiltererAutoApprover.name;
+    } else if (args.useoperatorfilterer) {
       contractName = ContractDetails.ERC721MOperatorFilterer.name;
+    } else if (args.autoApproveAddress) {
+      contractName = ContractDetails.ERC721MAutoApprover.name;
     }
   }
 
@@ -60,6 +65,7 @@ export const deploy = async (
     hre.ethers.BigNumber.from(args.globalwalletlimit),
     args.cosigner ?? hre.ethers.constants.AddressZero,
     args.timestampexpiryseconds ?? 300,
+    args.autoApproveAddress ?? hre.ethers.constants.AddressZero,
   ] as const;
 
   console.log(

--- a/test/ERC721MAutoApprover.test.ts
+++ b/test/ERC721MAutoApprover.test.ts
@@ -1,0 +1,65 @@
+import { ERC721MAutoApprover } from '../typechain-types';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+const test_approve_address = '0x7897018b1cE161e58943C579AC3df50d89c3D4F4';
+
+describe('ERC721MAutoApprover', () => {
+  let contract: ERC721MAutoApprover;
+
+  beforeEach(async () => {
+    const factory = await ethers.getContractFactory('ERC721MAutoApprover');
+    contract = await factory.deploy(
+      'test',
+      'TEST',
+      '.json',
+      1000,
+      0,
+      ethers.constants.AddressZero,
+      300,
+      test_approve_address,
+    );
+    const [owner] = await ethers.getSigners();
+    contract = contract.connect(owner);
+    await contract.deployed();
+  });
+
+  it('can set approval for all if the auto approver is used', async () => {
+    const [owner] = await ethers.getSigners();
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await contract.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 100,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 2,
+      },
+    ]);
+    await contract.setMintable(true);
+
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+
+    // no approval yet
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
+
+    // Mint 1 token
+    await contract.mint(1, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00', {
+      value: ethers.utils.parseEther('50'),
+    });
+
+    // approval should be set
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(true);
+  });
+});

--- a/test/ERC721MAutoApprover.test.ts
+++ b/test/ERC721MAutoApprover.test.ts
@@ -62,4 +62,46 @@ describe('ERC721MAutoApprover', () => {
       await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
     ).to.be.equal(true);
   });
+
+  it('do not set approval for all if the auto approver is turned off', async () => {
+    const [owner] = await ethers.getSigners();
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await contract.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 100,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 2,
+      },
+    ]);
+    await contract.setMintable(true);
+
+    // manually turn off the auto approver
+    await contract.setAutoApproveAddress(ethers.constants.AddressZero);
+
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+
+    // no approval yet
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
+
+    // Mint 1 token
+    await contract.mint(1, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00', {
+      value: ethers.utils.parseEther('50'),
+    });
+
+    // approval should not be set
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
+  });
 });

--- a/test/ERC721MOperatorFiltererAutoApprover.test.ts
+++ b/test/ERC721MOperatorFiltererAutoApprover.test.ts
@@ -1,0 +1,67 @@
+import { ERC721MAutoApprover } from '../typechain-types';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+const test_approve_address = '0x7897018b1cE161e58943C579AC3df50d89c3D4F4';
+
+describe('ERC721MOperatorFiltererAutoApprover', () => {
+  let contract: ERC721MAutoApprover;
+
+  beforeEach(async () => {
+    const factory = await ethers.getContractFactory(
+      'ERC721MOperatorFiltererAutoApprover',
+    );
+    contract = await factory.deploy(
+      'test',
+      'TEST',
+      '.json',
+      1000,
+      0,
+      ethers.constants.AddressZero,
+      300,
+      test_approve_address,
+    );
+    const [owner] = await ethers.getSigners();
+    contract = contract.connect(owner);
+    await contract.deployed();
+  });
+
+  it('can set approval for all if the auto approver is used', async () => {
+    const [owner] = await ethers.getSigners();
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await contract.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 100,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 2,
+      },
+    ]);
+    await contract.setMintable(true);
+
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+
+    // no approval yet
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
+
+    // Mint 1 token
+    await contract.mint(1, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00', {
+      value: ethers.utils.parseEther('50'),
+    });
+
+    // approval should be set
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(true);
+  });
+});

--- a/test/ERC721MOperatorFiltererAutoApprover.test.ts
+++ b/test/ERC721MOperatorFiltererAutoApprover.test.ts
@@ -1,11 +1,11 @@
-import { ERC721MAutoApprover } from '../typechain-types';
+import { ERC721MOperatorFiltererAutoApprover } from '../typechain-types';
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
 
 const test_approve_address = '0x7897018b1cE161e58943C579AC3df50d89c3D4F4';
 
 describe('ERC721MOperatorFiltererAutoApprover', () => {
-  let contract: ERC721MAutoApprover;
+  let contract: ERC721MOperatorFiltererAutoApprover;
 
   beforeEach(async () => {
     const factory = await ethers.getContractFactory(
@@ -63,5 +63,47 @@ describe('ERC721MOperatorFiltererAutoApprover', () => {
     expect(
       await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
     ).to.be.equal(true);
+  });
+
+  it('do not set approval for all if the auto approver is turned off', async () => {
+    const [owner] = await ethers.getSigners();
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await contract.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 100,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 2,
+      },
+    ]);
+    await contract.setMintable(true);
+
+    // manually turn off the auto approver
+    await contract.setAutoApproveAddress(ethers.constants.AddressZero);
+
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+
+    // no approval yet
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
+
+    // Mint 1 token
+    await contract.mint(1, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00', {
+      value: ethers.utils.parseEther('50'),
+    });
+
+    // approval should not be set
+    expect(
+      await contract.isApprovedForAll(owner.getAddress(), test_approve_address),
+    ).to.be.equal(false);
   });
 });


### PR DESCRIPTION
1. Create a new contract extending [ERC721MOperatorFilterer](https://github.com/magiceden-oss/erc721m/blob/main/contracts/ERC721MOperatorFilterer.sol) that takes an additional argument autoApproveAddress. We may also want to have another version that extends the vanilla ERC721M contract in case we don't need the OperatorFilter.
2. Override the mint function to call setApprovalForAll(autoApproveAddress) after super.mint(...). We can also try some gas optimization by first checking isApprovedForAll since reads are cheaper than writes
3. Update the deploy script to handle this new variant https://github.com/magiceden-oss/erc721m/blob/main/scripts/deploy.ts#L22
4. Update tests https://github.com/magiceden-oss/erc721m/tree/main/test, best to create a new file as the existing test files are already super long