### PR TITLE
Add autoapproveaddress into hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,6 +102,7 @@ task('deploy', 'Deploy ERC721M')
   .addParam('tokenurisuffix', 'token uri suffix', '.json')
   .addParam('globalwalletlimit', 'global wallet limit')
   .addParam('timestampexpiryseconds', 'timestamp expiry in seconds')
+  .addParam('autoapproveaddress', 'auto approve address')
   .addOptionalParam(
     'cosigner',
     'cosigner address (0x00...000 if not using cosign)',

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,20 +102,17 @@ task('deploy', 'Deploy ERC721M')
   .addParam('tokenurisuffix', 'token uri suffix', '.json')
   .addParam('globalwalletlimit', 'global wallet limit')
   .addParam('timestampexpiryseconds', 'timestamp expiry in seconds')
-  .addParam('autoapproveaddress', 'auto approve address')
   .addOptionalParam(
     'cosigner',
     'cosigner address (0x00...000 if not using cosign)',
     '0x0000000000000000000000000000000000000000',
   )
+  .addOptionalParam('autoapproveaddress', 'auto approve address')
   .addFlag(
     'increasesupply',
     'whether or not to enable increasing supply behavior',
   )
-  .addFlag(
-    'useoperatorfilterer',
-    'whether or not to use operator filterer',
-  )
+  .addFlag('useoperatorfilterer', 'whether or not to use operator filterer')
   .addFlag(
     'openedition',
     'whether or not a open edition mint (unlimited supply, 999,999,999)',

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -65,7 +65,7 @@ export const deploy = async (
     hre.ethers.BigNumber.from(args.globalwalletlimit),
     args.cosigner ?? hre.ethers.constants.AddressZero,
     args.timestampexpiryseconds ?? 300,
-    args.autoapproveaddress ?? hre.ethers.constants.AddressZero,
+    args.autoapproveaddress ? args.autoapproveaddress : {}
   ] as const;
 
   console.log(

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -65,7 +65,7 @@ export const deploy = async (
     hre.ethers.BigNumber.from(args.globalwalletlimit),
     args.cosigner ?? hre.ethers.constants.AddressZero,
     args.timestampexpiryseconds ?? 300,
-    args.autoapproveaddress ? args.autoapproveaddress : {}
+    args.autoapproveaddress ?? {}
   ] as const;
 
   console.log(


### PR DESCRIPTION
Example contract:
https://goerli.etherscan.io/address/0x720B49797369DB6177235F3B10Ed6EF9360AdA20

deploy to goerli:
```
npx hardhat --network goerli deploy --name destiny-test-autoapproval --symbol destiny-test-autoapproval --maxsupply 1000 --globalwalletlimit 0 --tokenurisuffix .json --timestampexpiryseconds 300 --autoapproveaddress 0x7897018b1cE161e58943C579AC3df50d89c3D4F4
```

```
Going to deploy ERC721MAutoApprover with params {
  "name": "destiny-test-autoapproval",
  "symbol": "destiny-test-autoapproval",
  "maxsupply": "1000",
  "globalwalletlimit": "0",
  "tokenurisuffix": ".json",
  "timestampexpiryseconds": "300",
  "autoapproveaddress": "0x7897018b1cE161e58943C579AC3df50d89c3D4F4",
  "cosigner": "0x0000000000000000000000000000000000000000",
  "increasesupply": false,
  "useoperatorfilterer": false,
  "openedition": false
}
Constructor params:  ["destiny-test-autoapproval","destiny-test-autoapproval",".json","1000","0","0x0000000000000000000000000000000000000000","300","0x7897018b1cE161e58943C579AC3df50d89c3D4F4"]
ERC721MAutoApprover deployed to: 0xe5c69167fbE4c24e249d83F61f4E45898D4374BB
```
verify:
```
npx hardhat verify --network goerli 0xe5c69167fbE4c24e249d83F61f4E45898D4374BB "destiny-test-autoapproval" "destiny-test-autoapproval" ".json" 1000 0 0x0000000000000000000000000000000000000000 300 0x7897018b1cE161e58943C579AC3df50d89c3D4F4
```

```
Successfully submitted source code for contract
contracts/ERC721MAutoApprover.sol:ERC721MAutoApprover at 0xe5c69167fbE4c24e249d83F61f4E45898D4374BB
```